### PR TITLE
Fix for misbehaving webviews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 build/
 .DS_Store
+process/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,20 +10,12 @@ gulp.task('process', function() {
 		host = 'http://ftlabs-screens-test.herokuapp.com';	
 	}
 	
-	gulp.src(['./src/scripts/main.js'])
+	gulp.src('./src/scripts/main.js')
 		.pipe( process( { context : {
 				host : host
 			}
 		}) )
 		.pipe( gulp.dest('./process/scripts/') )
-	;
-	
-	gulp.src(['./src/manifest.json'])
-		.pipe( process( { context : {
-				test : "-TEST"
-			}
-		}) )
-		.pipe( gulp.dest('./process') )
 	;
 	
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,8 +5,6 @@ const argv = require('yargs').argv;
 gulp.task('process', function() {
 	
 	var host = 'http://ftlabs-screens.herokuapp.com';
-	
-	console.log(argv.deploy);
 
 	if(argv.deploy === 'test'){
 		host = 'http://ftlabs-screens-test.herokuapp.com';	
@@ -21,10 +19,11 @@ gulp.task('process', function() {
 	;
 	
 	gulp.src(['./src/manifest.json'])
-		.pipe( process({
-			host
+		.pipe( process( { context : {
+				test : "-TEST"
+			}
 		}) )
-		.pipe( gulp.dest('./process/') )
+		.pipe( gulp.dest('./process') )
 	;
 	
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,15 +1,32 @@
 const gulp = require('gulp');
-const obt = require('origami-build-tools');
+const process = require('gulp-preprocess');
+const argv = require('yargs').argv;
 
-gulp.task('build', function() {
+gulp.task('process', function() {
 	
-	return obt.build.js({
-		js: './src/scripts/main.js',
-		buildJs: 'main.js',
-		buildFolder: './build/scripts/',
-		sourcemaps : false
-	});
+	var host = 'http://ftlabs-screens.herokuapp.com';
+	
+	console.log(argv.deploy);
 
+	if(argv.deploy === 'test'){
+		host = 'http://ftlabs-screens-test.herokuapp.com';	
+	}
+	
+	gulp.src(['./src/scripts/main.js'])
+		.pipe( process( { context : {
+				host : host
+			}
+		}) )
+		.pipe( gulp.dest('./process/scripts/') )
+	;
+	
+	gulp.src(['./src/manifest.json'])
+		.pipe( process({
+			host
+		}) )
+		.pipe( gulp.dest('./process/') )
+	;
+	
 });
 
-gulp.task('default', ['build']);
+gulp.task('default', ['process']);

--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "ftlabs-chrome-screens-app-kiosk",
   "description": "A kiosk-enabled Chrome app that ties into the FT Labs Screens system.",
   "scripts": {
-    "build-js": "mkdir -p build/scripts && obt build --js=src/scripts/main.js --buildFolder=build/scripts",
+    "build-js": "mkdir -p build/scripts && mkdir -p ./process/scripts && gulp process && obt build --js=process/scripts/main.js --buildFolder=build/scripts",
     "watch": "npm run build && sh -c 'nodemon -e js --watch src/scripts/ --exec \"npm run deploy\" & wait'",
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "npm run build-js",
     "deploy": "npm run clean && cp -R ./src ./build && npm run build && zip -r ./build/package.zip ./build",
-    "clean": "rm -rf ./build"
+    "clean": "rm -rf ./build && rm -rf ./process"
   },
   "author": "FTLabs",
   "license": "MIT",
@@ -15,11 +15,13 @@
     "babel-preset-es2015": "^6.3.13",
     "babelify": "^7.2.0",
     "browserify": "^12.0.1",
+    "ftlabs-screens-carousel": "^1.0.10",
+    "ftlabs-screens-viewer": "^3.0.0",
     "gulp": "^3.9.1",
+    "gulp-preprocess": "^2.0.0",
     "nodemon": "^1.8.1",
     "origami-build-tools": "^5.0.0",
     "whatwg-fetch": "^0.10.1",
-    "ftlabs-screens-carousel": "^1.0.10",
-    "ftlabs-screens-viewer": "^3.0.0"
+    "yargs": "^4.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "npm run build-js",
     "deploy": "npm run clean && cp -R ./src ./build && npm run build && zip -r ./build/package.zip ./build",
-    "clean": "rm -rf ./build && rm -rf ./process"
+    "clean": "rm -rf ./build && rm -rf ./process",
+    "deploy-test": "npm run clean && cp -R ./src ./build && npm run build-test && zip -r ./build/package.zip ./build",
+    "build-test": "npm run build-js-test",
+    "build-js-test": "mkdir -p build/scripts && mkdir -p ./process/scripts && gulp process --deploy=test && obt build --js=process/scripts/main.js --buildFolder=build/scripts"
   },
   "author": "FTLabs",
   "license": "MIT",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "FT Labs Screens (Kiosk)",
   "description": "A kiosk-enabled Chrome app that ties into the FT Labs Screens system.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "manifest_version": 2,
   "app": {
     "background": {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -83,17 +83,15 @@ const views = [].slice.call(document.querySelectorAll('webview'));
 function webViewLoaded() {
 	const currentActive = document.querySelector('webView.active');
 	if (currentActive) kickOutIframe(currentActive);
-	this.classList.remove('buffering');
-	this.classList.add('active');
+	this.setAttribute('class', 'active');
 	this.removeEventListener('load', webViewLoaded);
 	window.dispatchEvent(visibleEvt);
 }
 
 function kickOutIframe(webView) {
-	webView.classList.remove('active');
-	webView.classList.remove('buffering');
-	webView.classList.add('done');
-	setTimeout(() => webView.src = 'about:blank', 500);
+	
+	webView.setAttribute('class', 'done');
+	
 	webView.removeEventListener('contentload', webViewLoaded);
 
 	// remove self from the list
@@ -102,10 +100,10 @@ function kickOutIframe(webView) {
 
 function prepareIframetoLoad(webView, url) {
 	usedViews.push(webView);
-	webView.classList.add('buffering');
-	webView.classList.remove('done');
-	webView.src = url;
+	webView.setAttribute('class', 'buffering');
+
 	webView.addEventListener('contentload', webViewLoaded);
+	webView.src = url;
 }
 
 const usedViews = [];

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -163,8 +163,8 @@ window.onload = function() {
 
 		// Reset carousel countdown
 		window.removeEventListener('carousel-content-visible', onCarouselVisibleShowCountdown);
-		carouselCountdown.style.transform = 'scaleX(0)';
 		carouselCountdown.style.transition = 'none';
+		carouselCountdown.style.transform = 'scaleX(0)';
 		carouselCountdown.style.offsetHeight;
 
 		if (carousel) {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -209,6 +209,7 @@ window.onload = function() {
 	});
 
 	viewer.start();
-	bringDown.set();
 
 };
+
+	bringDown.set();

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -93,7 +93,7 @@ function kickOutIframe(webView) {
 	webView.setAttribute('class', 'done');
 	
 	webView.removeEventListener('contentload', webViewLoaded);
-
+	setTimeout(() => webView.src = 'about:blank', 500);
 	// remove self from the list
 	usedViews.splice(usedViews.indexOf(webView), 1);
 }

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -140,7 +140,7 @@ window.onload = function() {
 	const carouselCountdown = document.querySelector('#carousel-countdown');
 
 	let carousel;
-	const viewer = new Viewer('http://ftlabs-screens.herokuapp.com', chromeStorage);
+	const viewer = new Viewer('/* @echo host */', chromeStorage);		
 
 	function updateIDs() {
 		[].slice.call(document.querySelectorAll('.screen-id')).forEach(function(el) {
@@ -175,7 +175,7 @@ window.onload = function() {
 		}
 
 		if (Carousel.isCarousel(url)) {
-			carousel = new Carousel(url, 'http://ftlabs-screens.herokuapp.com');
+			carousel = new Carousel(url, '/* @echo host */');
 			carousel.on('change', function (url) {
 				updateUrl(url);
 				window.addEventListener('carousel-content-visible', onCarouselVisibleShowCountdown, false);

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -140,7 +140,7 @@ window.onload = function() {
 	const carouselCountdown = document.querySelector('#carousel-countdown');
 
 	let carousel;
-	const viewer = new Viewer('/* @echo host */', chromeStorage);		
+	const viewer = new Viewer('/* @echo host */', chromeStorage);
 
 	function updateIDs() {
 		[].slice.call(document.querySelectorAll('.screen-id')).forEach(function(el) {

--- a/src/window.html
+++ b/src/window.html
@@ -11,7 +11,7 @@
 <body class="">
 
 	<webview minwidth="1024" minheight="768"></webview>
-	<webview minwidth="1024" minheight="768"></webview>
+	<webview minwidth="1024" minheight="768" class="done"></webview>
 
 	<div id="disconnected">
 		<p><strong>Screen <span class='screen-id'></span></strong></p>

--- a/src/window.html
+++ b/src/window.html
@@ -10,8 +10,8 @@
 
 <body class="">
 
-	<webview minwidth="1024" minheight="768"></webview>
-	<webview minwidth="1024" minheight="768" class="done"></webview>
+	<webview minwidth="1024" minheight="768" partition="persist:ftlabs-screens"></webview>
+	<webview minwidth="1024" minheight="768" partition="persist:ftlabs-screens" class="done"></webview>
 
 	<div id="disconnected">
 		<p><strong>Screen <span class='screen-id'></span></strong></p>


### PR DESCRIPTION
Webviews did not have initial states and were, in some circumstance, subject to race conditions that would result in webviews that were active not being visible and vice versa. Rather than adding/removing classes as the code deemed, the most recent state simply overwrites the lot.

Also adjusted the build pipeline to allow for deployment to point at both the test and live servers.
